### PR TITLE
test/e2e: Update auth registry testing

### DIFF
--- a/src/cloud-api-adaptor/test/e2e/assessment_helpers.go
+++ b/src/cloud-api-adaptor/test/e2e/assessment_helpers.go
@@ -708,12 +708,34 @@ func DeleteAndWaitForNamespace(ctx context.Context, client klient.Client, namesp
 	return nil
 }
 
-func AddImagePullSecretToDefaultServiceAccount(ctx context.Context, client klient.Client, secretName string) error {
+func getDefaultServiceAccount(ctx context.Context, client klient.Client) (*v1.ServiceAccount, error) {
+	clientSet, err := kubernetes.NewForConfig(client.RESTConfig())
+	if err != nil {
+		return nil, err
+	}
+	serviceAccount, err := clientSet.CoreV1().ServiceAccounts(E2eNamespace).Get(context.TODO(), "default", metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return serviceAccount, nil
+}
+
+func setImagePullSecretsOnServiceAccount(ctx context.Context, client klient.Client, serviceAccount *v1.ServiceAccount, imagePullSecrets []v1.LocalObjectReference) error {
 	clientSet, err := kubernetes.NewForConfig(client.RESTConfig())
 	if err != nil {
 		return err
 	}
-	serviceAccount, err := clientSet.CoreV1().ServiceAccounts(E2eNamespace).Get(context.TODO(), "default", metav1.GetOptions{})
+	serviceAccount.ImagePullSecrets = imagePullSecrets
+	_, err = clientSet.CoreV1().ServiceAccounts(E2eNamespace).Update(context.TODO(), serviceAccount, metav1.UpdateOptions{})
+	if err != nil {
+		return err
+	}
+	log.Infof("ServiceAccount %s updated successfully.", "default")
+	return nil
+}
+
+func AddImagePullSecretToDefaultServiceAccount(ctx context.Context, client klient.Client, secretName string) error {
+	serviceAccount, err := getDefaultServiceAccount(ctx, client)
 	if err != nil {
 		return err
 	}
@@ -725,13 +747,29 @@ func AddImagePullSecretToDefaultServiceAccount(ctx context.Context, client klien
 		}
 	}
 	if !secretExists {
-		// Update the ServiceAccount to add the imagePullSecret
-		serviceAccount.ImagePullSecrets = append(serviceAccount.ImagePullSecrets, v1.LocalObjectReference{Name: secretName})
-		_, err := clientSet.CoreV1().ServiceAccounts(E2eNamespace).Update(context.TODO(), serviceAccount, metav1.UpdateOptions{})
+		imagePullSecrets := append(serviceAccount.ImagePullSecrets, v1.LocalObjectReference{Name: secretName})
+		err := setImagePullSecretsOnServiceAccount(ctx, client, serviceAccount, imagePullSecrets)
 		if err != nil {
 			return err
 		}
-		log.Infof("ServiceAccount %s updated successfully.", "default")
+	}
+	return nil
+}
+
+func RemoveImagePullSecretFromDefaultServiceAccount(ctx context.Context, client klient.Client, secretName string) error {
+	serviceAccount, err := getDefaultServiceAccount(ctx, client)
+	if err != nil {
+		return err
+	}
+	newSecrets := []v1.LocalObjectReference{}
+	for _, secret := range serviceAccount.ImagePullSecrets {
+		if secret.Name != secretName {
+			newSecrets = append(newSecrets, secret)
+		}
+	}
+	err = setImagePullSecretsOnServiceAccount(ctx, client, serviceAccount, newSecrets)
+	if err != nil {
+		return err
 	}
 	return nil
 }

--- a/src/cloud-api-adaptor/test/e2e/assessment_runner.go
+++ b/src/cloud-api-adaptor/test/e2e/assessment_runner.go
@@ -7,18 +7,15 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 	"time"
 
 	yaml "gopkg.in/yaml.v2"
 	batchv1 "k8s.io/api/batch/v1"
-	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"sigs.k8s.io/e2e-framework/klient"
 	"sigs.k8s.io/e2e-framework/klient/wait"
 	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
 	"sigs.k8s.io/e2e-framework/pkg/env"
@@ -67,7 +64,7 @@ type TestCase struct {
 	expectedPodEventErrorString string
 	podState                    v1.PodPhase
 	imagePullTimer              bool
-	noAuthJson                  bool
+	saImagePullSecret           string
 	deletionWithin              time.Duration
 	expectedInstanceType        string
 	isNydusSnapshotter          bool
@@ -165,46 +162,14 @@ func (tc *TestCase) WithPodWatcher() *TestCase {
 	return tc
 }
 
-func (tc *TestCase) WithNoAuthJson() *TestCase {
-	tc.noAuthJson = true
+func (tc *TestCase) WithSAImagePullSecret(secretName string) *TestCase {
+	tc.saImagePullSecret = secretName
 	return tc
 }
 
 func (tc *TestCase) WithNydusSnapshotter() *TestCase {
 	tc.isNydusSnapshotter = true
 	return tc
-}
-
-func writeAuthSecret(client klient.Client, ctx context.Context) error {
-	secret := &corev1.Secret{}
-	secretExists := false
-	err := client.Resources().Get(ctx, DEFAULT_AUTH_SECRET, E2eNamespace, secret)
-	if err == nil {
-		secretExists = true
-	}
-	if secretExists {
-		return nil
-	}
-
-	template := `{
-		"auths": {
-			"%s": {
-				"auth": "%s"
-			}
-		}
-	}`
-	cred := os.Getenv("REGISTRY_CREDENTIAL_ENCODED")
-	registryName := strings.Split(os.Getenv("AUTHENTICATED_REGISTRY_IMAGE"), "/")[0]
-	authfile := []byte(fmt.Sprintf(template, registryName, cred))
-
-	secretData := map[string][]byte{v1.DockerConfigJsonKey: authfile}
-	secret = NewSecret(E2eNamespace, DEFAULT_AUTH_SECRET, secretData, v1.SecretTypeDockerConfigJson)
-	err = client.Resources().Create(ctx, secret)
-	if err != nil {
-		return err
-	}
-
-	return AddImagePullSecretToDefaultServiceAccount(ctx, client, DEFAULT_AUTH_SECRET)
 }
 
 func (tc *TestCase) Run() {
@@ -217,12 +182,6 @@ func (tc *TestCase) Run() {
 
 			if tc.configMap != nil {
 				if err = client.Resources().Create(ctx, tc.configMap); err != nil {
-					t.Fatal(err)
-				}
-			}
-
-			if os.Getenv("REGISTRY_CREDENTIAL_ENCODED") != "" {
-				if err = writeAuthSecret(client, ctx); err != nil {
 					t.Fatal(err)
 				}
 			}
@@ -247,6 +206,12 @@ func (tc *TestCase) Run() {
 				}
 			}
 
+			if tc.saImagePullSecret != "" {
+				if err = AddImagePullSecretToDefaultServiceAccount(ctx, client, tc.saImagePullSecret); err != nil {
+					t.Fatal(err)
+				}
+			}
+
 			if tc.job != nil {
 				if err = client.Resources().Create(ctx, tc.job); err != nil {
 					t.Fatal(err)
@@ -254,24 +219,6 @@ func (tc *TestCase) Run() {
 				if err = wait.For(conditions.New(client.Resources()).JobCompleted(tc.job), wait.WithTimeout(WAIT_JOB_RUNNING_TIMEOUT)); err != nil {
 					//Using t.log instead of t.Fatal here because we need to assess number of success and failure pods if job fails to complete
 					t.Log(err)
-				}
-			}
-
-			if tc.noAuthJson {
-				clientSet, err := kubernetes.NewForConfig(client.RESTConfig())
-				if err != nil {
-					t.Fatal(err)
-				}
-				_, err = clientSet.CoreV1().Secrets(E2eNamespace).Get(ctx, DEFAULT_AUTH_SECRET, metav1.GetOptions{})
-				if err == nil {
-					t.Logf("Deleting pre-existing %v...", DEFAULT_AUTH_SECRET)
-					if err = clientSet.CoreV1().Secrets(E2eNamespace).Delete(ctx, DEFAULT_AUTH_SECRET, metav1.DeleteOptions{}); err != nil {
-						t.Fatal(err)
-					}
-					t.Logf("Creating empty %v...", DEFAULT_AUTH_SECRET)
-					if err = client.Resources().Create(ctx, &v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: DEFAULT_AUTH_SECRET, Namespace: E2eNamespace}, Type: v1.SecretTypeOpaque}); err != nil {
-						t.Fatal(err)
-					}
 				}
 			}
 
@@ -493,13 +440,9 @@ func (tc *TestCase) Run() {
 				}
 			}
 
-			if os.Getenv("REGISTRY_CREDENTIAL_ENCODED") != "" {
-				clientSet, err := kubernetes.NewForConfig(client.RESTConfig())
-				if err != nil {
+			if tc.saImagePullSecret != "" {
+				if err = RemoveImagePullSecretFromDefaultServiceAccount(ctx, client, tc.saImagePullSecret); err != nil {
 					t.Fatal(err)
-				}
-				if err = clientSet.CoreV1().Secrets(E2eNamespace).Delete(ctx, DEFAULT_AUTH_SECRET, metav1.DeleteOptions{}); err != nil {
-					t.Error(err)
 				}
 			}
 

--- a/src/cloud-api-adaptor/test/e2e/common.go
+++ b/src/cloud-api-adaptor/test/e2e/common.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -402,6 +403,22 @@ func NewConfigMap(namespace, name string, configMapData map[string]string) *core
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
 		Data:       configMapData,
 	}
+}
+
+// NewImagePullSecret returns a new imagePull secret object.
+func NewImagePullSecret(namespace, name string, image string, credentials string) *corev1.Secret {
+	registryName := strings.Split(image, "/")[0]
+	template := `{
+	"auths": {
+		"%s": {
+			"auth": "%s"
+		}
+	}
+}`
+	authJSON := fmt.Sprintf(template, registryName, credentials)
+	secretData := map[string][]byte{v1.DockerConfigJsonKey: []byte(authJSON)}
+
+	return NewSecret(namespace, name, secretData, v1.SecretTypeDockerConfigJson)
 }
 
 // NewSecret returns a new secret object.

--- a/src/cloud-api-adaptor/test/e2e/docker_test.go
+++ b/src/cloud-api-adaptor/test/e2e/docker_test.go
@@ -136,10 +136,19 @@ func TestDockerCreatePeerPodWithAuthenticatedImageWithoutCredentials(t *testing.
 	}
 }
 
-func TestDockerCreatePeerPodWithAuthenticatedImageWithValidCredentials(t *testing.T) {
+func TestDockerCreatePeerPodWithAuthenticatedImageWithImagePullSecretInServiceAccount(t *testing.T) {
 	assert := DockerAssert{}
 	if os.Getenv("REGISTRY_CREDENTIAL_ENCODED") != "" && os.Getenv("AUTHENTICATED_REGISTRY_IMAGE") != "" {
-		DoTestCreatePeerPodWithAuthenticatedImageWithValidCredentials(t, testEnv, assert)
+		DoTestCreatePeerPodWithAuthenticatedImageWithImagePullSecretInServiceAccount(t, testEnv, assert)
+	} else {
+		t.Skip("Registry Credentials, or authenticated image name not exported")
+	}
+}
+
+func TestDockerCreatePeerPodWithAuthenticatedImageWithImagePullSecretOnPod(t *testing.T) {
+	assert := DockerAssert{}
+	if os.Getenv("REGISTRY_CREDENTIAL_ENCODED") != "" && os.Getenv("AUTHENTICATED_REGISTRY_IMAGE") != "" {
+		DoTestCreatePeerPodWithAuthenticatedImageWithImagePullSecretOnPod(t, testEnv, assert)
 	} else {
 		t.Skip("Registry Credentials, or authenticated image name not exported")
 	}

--- a/src/cloud-api-adaptor/test/e2e/ibmcloud_test.go
+++ b/src/cloud-api-adaptor/test/e2e/ibmcloud_test.go
@@ -146,12 +146,23 @@ func TestCreatePeerPodWithPVC(t *testing.T) {
 	}
 }
 
-func TestCreatePeerPodWithAuthenticatedImageWithValidCredentials(t *testing.T) {
+func TestIBMCloudCreatePeerPodWithAuthenticatedImageWithImagePullSecretOnPod(t *testing.T) {
 	assert := IBMCloudAssert{
 		VPC: pv.IBMCloudProps.VPC,
 	}
 	if os.Getenv("REGISTRY_CREDENTIAL_ENCODED") != "" && os.Getenv("AUTHENTICATED_REGISTRY_IMAGE") != "" {
-		DoTestCreatePeerPodWithAuthenticatedImageWithValidCredentials(t, testEnv, assert)
+		DoTestCreatePeerPodWithAuthenticatedImageWithImagePullSecretOnPod(t, testEnv, assert)
+	} else {
+		t.Skip("Registry Credentials not exported")
+	}
+}
+
+func TestIBMCloudCreatePeerPodWithAuthenticatedImageWithImagePullSecretInServiceAccount(t *testing.T) {
+	assert := IBMCloudAssert{
+		VPC: pv.IBMCloudProps.VPC,
+	}
+	if os.Getenv("REGISTRY_CREDENTIAL_ENCODED") != "" && os.Getenv("AUTHENTICATED_REGISTRY_IMAGE") != "" {
+		DoTestCreatePeerPodWithAuthenticatedImageWithImagePullSecretInServiceAccount(t, testEnv, assert)
 	} else {
 		t.Skip("Registry Credentials not exported")
 	}

--- a/src/cloud-api-adaptor/test/e2e/libvirt_test.go
+++ b/src/cloud-api-adaptor/test/e2e/libvirt_test.go
@@ -232,10 +232,19 @@ func TestLibvirtCreatePeerPodWithAuthenticatedImageWithoutCredentials(t *testing
 	}
 }
 
-func TestLibvirtCreatePeerPodWithAuthenticatedImageWithValidCredentials(t *testing.T) {
+func TestLibvirtCreatePeerPodWithAuthenticatedImageWithImagePullSecretInServiceAccount(t *testing.T) {
 	assert := LibvirtAssert{}
 	if os.Getenv("REGISTRY_CREDENTIAL_ENCODED") != "" && os.Getenv("AUTHENTICATED_REGISTRY_IMAGE") != "" {
-		DoTestCreatePeerPodWithAuthenticatedImageWithValidCredentials(t, testEnv, assert)
+		DoTestCreatePeerPodWithAuthenticatedImageWithImagePullSecretInServiceAccount(t, testEnv, assert)
+	} else {
+		t.Skip("Registry Credentials, or authenticated image name not exported")
+	}
+}
+
+func TestLibvirtCreatePeerPodWithAuthenticatedImageWithImagePullSecretOnPod(t *testing.T) {
+	assert := LibvirtAssert{}
+	if os.Getenv("REGISTRY_CREDENTIAL_ENCODED") != "" && os.Getenv("AUTHENTICATED_REGISTRY_IMAGE") != "" {
+		DoTestCreatePeerPodWithAuthenticatedImageWithImagePullSecretOnPod(t, testEnv, assert)
 	} else {
 		t.Skip("Registry Credentials, or authenticated image name not exported")
 	}


### PR DESCRIPTION
Now that our main mechanism for imagePullSecrets is to create them in the ServiceAccount, or on the pod, rather than going via auth-json-secret in the kustomise, we can switch to use a more normal imagePullSecrets path